### PR TITLE
Fix paraview launch button not working on macOS

### DIFF
--- a/CfdOF/CfdTools.py
+++ b/CfdOF/CfdTools.py
@@ -1331,6 +1331,10 @@ def startParaview(case_path, script_name, console_message_fn):
             for key in env_vars:
                 env.insert(key, env_vars[key])
             removeAppimageEnvironment(env)
+            # FreeCAD sets PYTHONHOME/PYTHONPATH to its own Python; strip them so ParaView's bundled Python is used.
+            for py_var in ("PYTHONHOME", "PYTHONPATH"):
+                if env.contains(py_var):
+                    env.remove(py_var)
             proc.setProcessEnvironment(env)
             success = proc.startDetached()
             if not success:
@@ -1345,6 +1349,9 @@ def startParaview(case_path, script_name, console_message_fn):
         proc.setWorkingDirectory(case_path)
         env = QtCore.QProcessEnvironment.systemEnvironment()
         removeAppimageEnvironment(env)
+        for py_var in ("PYTHONHOME", "PYTHONPATH"):
+            if env.contains(py_var):
+                env.remove(py_var)
         proc.setProcessEnvironment(env)
         success = proc.startDetached()
         if success:

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
     <name>CfdOF</name>
     <description>Computational Fluid Dynamics (CFD) for FreeCAD based on OpenFOAM</description>
-    <version>1.33.2</version>
+    <version>1.33.3</version>
     <maintainer email="oliveroxtoby@gmail.com">Oliver Oxtoby</maintainer>
     <license file="LICENSE">LGPL-3.0-or-later</license>
     <url type="repository" branch="master">https://github.com/jaheyns/CfdOF</url>


### PR DESCRIPTION
Paraview being launched with FreeCAD's PYTHONHOME/PYTHONPATH seems to prevent `--script` from working correctly. This PR resolves #232.