### PR TITLE
Normalize Copyright Statements

### DIFF
--- a/CfdOF/CfdAnalysis.py
+++ b/CfdOF/CfdAnalysis.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2024 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2024 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdConsoleProcess.py
+++ b/CfdOF/CfdConsoleProcess.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdDependencyData.py
+++ b/CfdOF/CfdDependencyData.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2025 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdFaceSelectWidget.py
+++ b/CfdOF/CfdFaceSelectWidget.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdImportSTL.py
+++ b/CfdOF/CfdImportSTL.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2020 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2020 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdOpenPreferencesPage.py
+++ b/CfdOF/CfdOpenPreferencesPage.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024 hasecilu <hasecilu@tuta.io>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2024 hasecilu <hasecilu@tuta.io>                             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdPreferencePage.py
+++ b/CfdOF/CfdPreferencePage.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017-2018 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>          #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdReloadWorkbench.py
+++ b/CfdOF/CfdReloadWorkbench.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2023 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2023 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdTestCommands.py
+++ b/CfdOF/CfdTestCommands.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2024 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdTimePlot.py
+++ b/CfdOF/CfdTimePlot.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/CfdTools.py
+++ b/CfdOF/CfdTools.py
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2015 Qingfeng Xia <qingfeng.xia@eng.ox.ac.uk>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2015 - Qingfeng Xia <qingfeng xia eng.ox.ac.uk>              #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2026 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022-2024 Jonathan Bergh <bergh.jonathan@gmail.com>          #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/CfdDynamicMeshRefinement.py
+++ b/CfdOF/Mesh/CfdDynamicMeshRefinement.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
+# SPDX-FileCopyrightText: 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
-#   Copyright (c) 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/CfdMesh.py
+++ b/CfdOF/Mesh/CfdMesh.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2019-2024 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/CfdMeshRefinement.py
+++ b/CfdOF/Mesh/CfdMeshRefinement.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/CfdMeshTools.py
+++ b/CfdOF/Mesh/CfdMeshTools.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017-2018 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>          #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/TaskPanelCfdDynamicMeshInterfaceRefinement.py
+++ b/CfdOF/Mesh/TaskPanelCfdDynamicMeshInterfaceRefinement.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
+# SPDX-FileCopyrightText: 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
-#   Copyright (c) 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/TaskPanelCfdDynamicMeshShockRefinement.py
+++ b/CfdOF/Mesh/TaskPanelCfdDynamicMeshShockRefinement.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/TaskPanelCfdMesh.py
+++ b/CfdOF/Mesh/TaskPanelCfdMesh.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2016 Bernd Hahnebach <bernd@bimstatik.org>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2016 - Bernd Hahnebach <bernd@bimstatik.org>                 #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Mesh/TaskPanelCfdMeshRefinement.py
+++ b/CfdOF/Mesh/TaskPanelCfdMeshRefinement.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/PostProcess/CfdReportingFunction.py
+++ b/CfdOF/PostProcess/CfdReportingFunction.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
+# SPDX-FileCopyrightText: 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
-#   Copyright (c) 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/PostProcess/TaskPanelCfdReportingFunction.py
+++ b/CfdOF/PostProcess/TaskPanelCfdReportingFunction.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
+# SPDX-FileCopyrightText: 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
-#   Copyright (c) 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdCaseWriterFoam.py
+++ b/CfdOF/Solve/CfdCaseWriterFoam.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022-2024 Jonathan Bergh <bergh.jonathan@gmail.com>          #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdFluidBoundary.py
+++ b/CfdOF/Solve/CfdFluidBoundary.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdFluidMaterial.py
+++ b/CfdOF/Solve/CfdFluidMaterial.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2013 Juergen Riegel <FreeCAD@juergen-riegel.net>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2013-2015 - Juergen Riegel <FreeCAD@juergen-riegel.net>      #
-#   Copyright (c) 2017-2018 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>          #
-#   Copyright (c) 2017-2018 Alfred Bogaers (CSIR) <abogaers@csir.co.za>        #
-#   Copyright (c) 2017-2018 Johan Heyns (CSIR) <jheyns@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdInitialiseFlowField.py
+++ b/CfdOF/Solve/CfdInitialiseFlowField.py
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2013 Juergen Riegel <FreeCAD@juergen-riegel.net>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2013-2015 - Juergen Riegel <FreeCAD@juergen-riegel.net>      #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2019-2023 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdPhysicsSelection.py
+++ b/CfdOF/Solve/CfdPhysicsSelection.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017-2018 Alfred Bogaers (CSIR) <abogaers@csir.co.za>        #
-#   Copyright (c) 2017-2018 Johan Heyns (CSIR) <jheyns@csir.co.za>             #
-#   Copyright (c) 2017-2018 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>          #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdRunnableFoam.py
+++ b/CfdOF/Solve/CfdRunnableFoam.py
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2015 Qingfeng Xia <qingfeng.xia@eng.ox.ac.uk>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2015 - Qingfeng Xia <qingfeng.xia()eng.ox.ac.uk>             #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdScalarTransportFunction.py
+++ b/CfdOF/Solve/CfdScalarTransportFunction.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
+# SPDX-FileCopyrightText: 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
-#   Copyright (c) 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdSolverFoam.py
+++ b/CfdOF/Solve/CfdSolverFoam.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2015 Qingfeng Xia <qingfeng.xia@eng.ox.ac.uk>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2015 - Qingfeng Xia <qingfeng.xia()eng.ox.ac.uk>             #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/CfdZone.py
+++ b/CfdOF/Solve/CfdZone.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2019-2024 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/TaskPanelCfdFluidBoundary.py
+++ b/CfdOF/Solve/TaskPanelCfdFluidBoundary.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/TaskPanelCfdFluidProperties.py
+++ b/CfdOF/Solve/TaskPanelCfdFluidProperties.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017-2018 Johan Heyns (CSIR) <jheyns@csir.co.za>             #
-#   Copyright (c) 2017-2018 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>          #
-#   Copyright (c) 2017-2018 Alfred Bogaers (CSIR) <abogaers@csir.co.za>        #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/TaskPanelCfdInitialiseInternalFlowField.py
+++ b/CfdOF/Solve/TaskPanelCfdInitialiseInternalFlowField.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/TaskPanelCfdPhysicsSelection.py
+++ b/CfdOF/Solve/TaskPanelCfdPhysicsSelection.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017-2018 Johan Heyns (CSIR) <jheyns@csir.co.za>             #
-#   Copyright (c) 2017-2018 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>          #
-#   Copyright (c) 2017-2018 Alfred Bogaers (CSIR) <abogaers@csir.co.za>        #
-#   Copyright (c) 2019-2022 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/TaskPanelCfdScalarTransportFunctions.py
+++ b/CfdOF/Solve/TaskPanelCfdScalarTransportFunctions.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
+# SPDX-FileCopyrightText: 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>               #
-#   Copyright (c) 2022 Oliver Oxtoby <oliveroxtoby@gmail.com>                  #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/TaskPanelCfdSolverControl.py
+++ b/CfdOF/Solve/TaskPanelCfdSolverControl.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2016 Qingfeng Xia <qingfeng.xia@eng.ox.ac.uk>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2016 - Qingfeng Xia <qingfeng.xia()eng.ox.ac.uk>             #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2019-2025 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/Solve/TaskPanelCfdZone.py
+++ b/CfdOF/Solve/TaskPanelCfdZone.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2019-2024 Oliver Oxtoby <oliveroxtoby@gmail.com>             #
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/TemplateBuilder.py
+++ b/CfdOF/TemplateBuilder.py
@@ -3,9 +3,9 @@
 
 ################################################################################
 #                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/CfdOF/WindowsRunWrapper.py
+++ b/CfdOF/WindowsRunWrapper.py
@@ -3,9 +3,9 @@
 
 ################################################################################
 #                                                                              #
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>               #
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>                  #
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>             #
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/Data/CfdFluidMaterialProperties/AirCompressible.FCMat
+++ b/Data/CfdFluidMaterialProperties/AirCompressible.FCMat
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: 2016 CSIR, South Africa
+; SPDX-FileCopyrightText: 2021 Oliver Oxtoby
 ; AirCompressible
 ;
 ; FreeCAD Material card: see https://www.freecad.org/wiki/Material

--- a/Data/CfdFluidMaterialProperties/AirIsothermal.FCMat
+++ b/Data/CfdFluidMaterialProperties/AirIsothermal.FCMat
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: 2016 CSIR, South Africa
+; SPDX-FileCopyrightText: 2021 Oliver Oxtoby
 ; AirIsothermal
 ;
 ; FreeCAD Material card: see https://www.freecad.org/wiki/Material

--- a/Data/CfdFluidMaterialProperties/Gasoline.FCMat
+++ b/Data/CfdFluidMaterialProperties/Gasoline.FCMat
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: 2016 CSIR, South Africa
+; SPDX-FileCopyrightText: 2021 Oliver Oxtoby
 ; Gasoline
 ;
 ; FreeCAD Material card: see https://www.freecad.org/wiki/Material

--- a/Data/CfdFluidMaterialProperties/OilSAE10W.FCMat
+++ b/Data/CfdFluidMaterialProperties/OilSAE10W.FCMat
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: 2016 CSIR, South Africa
+; SPDX-FileCopyrightText: 2021 Oliver Oxtoby
 ; OilSAE10W
 ;
 ; FreeCAD Material card: see https://www.freecad.org/wiki/Material

--- a/Data/CfdFluidMaterialProperties/Readme.txt
+++ b/Data/CfdFluidMaterialProperties/Readme.txt
@@ -1,9 +1,6 @@
 This is the FreeCAD fluid material library. It's intended to gather
 the most common fluid properties.
 
-(c) 2016 CSIR, South Africa
-(c) 2021 Oliver Oxtoby
-
 Please verify the fluid material properties before use. It aims to
 serve as a convenience and does not aim to be a comprehensive
 reference.

--- a/Data/CfdFluidMaterialProperties/SeaWater.FCMat
+++ b/Data/CfdFluidMaterialProperties/SeaWater.FCMat
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: 2016 CSIR, South Africa
+; SPDX-FileCopyrightText: 2021 Oliver Oxtoby
 ; SeaWater
 ;
 ; FreeCAD Material card: see https://www.freecad.org/wiki/Material

--- a/Data/CfdFluidMaterialProperties/WaterIncompressible.FCMat
+++ b/Data/CfdFluidMaterialProperties/WaterIncompressible.FCMat
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: 2016 CSIR, South Africa
+; SPDX-FileCopyrightText: 2021 Oliver Oxtoby
 ; WaterIncompressible
 ;
 ; FreeCAD Material card: see https://www.freecad.org/wiki/Material

--- a/Data/CfdFluidMaterialProperties/WaterIsothermal.FCMat
+++ b/Data/CfdFluidMaterialProperties/WaterIsothermal.FCMat
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: 2016 CSIR, South Africa
+; SPDX-FileCopyrightText: 2021 Oliver Oxtoby
 ; WaterIsothermal
 ;
 ; FreeCAD Material card: see https://www.freecad.org/wiki/Material

--- a/Init.py
+++ b/Init.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2021 Oliver Oxtoby <oliveroxtoby@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2021 Oliver Oxtoby <oliveroxtoby@gmail.com>             *
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/InitGui.py
+++ b/InitGui.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2014 Bernd Hahnebach <bernd@bimstatik.org>
+# SPDX-FileCopyrightText: 2016 Qingfeng Xia <iesensor.com>
+# SPDX-FileCopyrightText: 2017 Andrew Gill (CSIR) <agill@csir.co.za>
+# SPDX-FileCopyrightText: 2019 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   (c) bernd hahnebach (bernd@bimstatik.org) 2014                        *
-#   (c) qingfeng xia @ iesensor.com 2016                                  *
-#   Copyright (c) 2017 Andrew Gill (CSIR) <agill@csir.co.za>              *
-#   Copyright (c) 2019-2024 Oliver Oxtoby <oliveroxtoby@gmail.com>        *
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>          *
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #

--- a/TestCfdOF.py
+++ b/TestCfdOF.py
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2015 Przemo Firszt <przemo@firszt.eu>
+# SPDX-FileCopyrightText: 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>
+# SPDX-FileCopyrightText: 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>
+# SPDX-FileCopyrightText: 2021 Oliver Oxtoby <oliveroxtoby@gmail.com>
+# SPDX-FileCopyrightText: 2022 Jonathan Bergh <bergh.jonathan@gmail.com>
 # SPDX-FileNotice: Part of the CfdOF addon.
 
 ################################################################################
-#                                                                              #
-#   Copyright (c) 2015 - Przemo Firszt <przemo@firszt.eu>                 *
-#   Copyright (c) 2017 Johan Heyns (CSIR) <jheyns@csir.co.za>             *
-#   Copyright (c) 2017 Oliver Oxtoby (CSIR) <ooxtoby@csir.co.za>          *
-#   Copyright (c) 2017 Alfred Bogaers (CSIR) <abogaers@csir.co.za>        *
-#   Copyright (c) 2021-2024 Oliver Oxtoby <oliveroxtoby@gmail.com>        *
-#   Copyright (c) 2022 Jonathan Bergh <bergh.jonathan@gmail.com>          *
 #                                                                              #
 #   This program is free software; you can redistribute it and/or              #
 #   modify it under the terms of the GNU Lesser General Public                 #


### PR DESCRIPTION
Moved copyright statements into SPDX annotations.
Also normalized the time ranges.

FYI unless you have an end year like with the 
CSIR ones, you don't need to specify one, in
general copyright just continues on.

( Disregarding country specific copyright 
range limits and extensions )