### PR TITLE
use of2512 in /use/lib/openfoam/ like any other demo

### DIFF
--- a/Data/TestFiles/cases/DamBreak3D/case/Allrun
+++ b/Data/TestFiles/cases/DamBreak3D/case/Allrun
@@ -26,7 +26,7 @@ runCommand()
 }
 
 # Unset and source bashrc
-FOAMDIR="/opt/openfoam13"
+FOAMDIR="/usr/lib/openfoam/openfoam2512"
 if [ ! -z "$FOAMDIR" ]
 then
     source "$FOAMDIR/etc/config.sh/unset" 2> /dev/null


### PR DESCRIPTION
in this [commit](https://github.com/jaheyns/CfdOF/commit/179b8b8fa472317178ce55049ef1d11dea3f6824) you make the battery demo use of13 installed in /opt and I think it was unintentional because you did not change it in `Allrun.bat` file in the same demo
