### PR TITLE
Add solid thermal material cards

### DIFF
--- a/Data/CfdFluidMaterialProperties/AcrylicSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/AcrylicSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; AcrylicSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Acrylic_solid
+Type = Solid
+Description = Acrylic PMMA solid thermal properties
+Density = 1180 kg/m^3
+ThermalConductivity = 0.189 W/m/K
+SpecificHeat = 1500 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=a5e93a1f1fff43bcbac5b6ca51b8981f

--- a/Data/CfdFluidMaterialProperties/AluminiumSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/AluminiumSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; AluminiumSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Aluminium_solid
+Type = Solid
+Description = Aluminium solid thermal properties for CHT simulation
+Density = 2699 kg/m^3
+ThermalConductivity = 237 W/m/K
+SpecificHeat = 897 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=0cd1edf33ac145ee93a0aa6fc666c0e0

--- a/Data/CfdFluidMaterialProperties/BrassSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/BrassSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; BrassSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Brass_solid
+Type = Solid
+Description = Brass solid thermal properties
+Density = 8510 kg/m^3
+ThermalConductivity = 85.1 W/m/K
+SpecificHeat = 379 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=d3bd4617903543ada92f4c101c2a20e5

--- a/Data/CfdFluidMaterialProperties/BrickSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/BrickSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; BrickSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Brick_solid
+Type = Solid
+Description = Common brick solid thermal properties
+Density = 1920 kg/m^3
+ThermalConductivity = 0.72 W/m/K
+SpecificHeat = 840 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=4288c4f80e77437893b26c4a56a98171

--- a/Data/CfdFluidMaterialProperties/CopperSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/CopperSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; CopperSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Copper_solid
+Type = Solid
+Description = Copper solid thermal properties
+Density = 8930 kg/m^3
+ThermalConductivity = 385 W/m/K
+SpecificHeat = 385 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=9aebe83845c04c1db5126fada6f76f7e

--- a/Data/CfdFluidMaterialProperties/FiberglassSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/FiberglassSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; FiberglassSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Fiberglass_solid
+Type = Solid
+Description = E-glass fiber solid thermal properties
+Density = 2570 kg/m^3
+ThermalConductivity = 1.30 W/m/K
+SpecificHeat = 810 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=d9c18047c49147a2a7c0b0bb1743e812

--- a/Data/CfdFluidMaterialProperties/FireInsulationBrickSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/FireInsulationBrickSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; FireInsulationBrickSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = FireInsulationBrick_solid
+Type = Solid
+Description = Skamol SUPER 1100 E calcium silicate refractory insulation solid thermal properties
+Density = 245 kg/m^3
+ThermalConductivity = 0.070 W/m/K
+SpecificHeat = 840 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=052e271dc1f7447aba062bdf1e662e75

--- a/Data/CfdFluidMaterialProperties/GlassSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/GlassSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; GlassSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Glass_solid
+Type = Solid
+Description = Borosilicate glass solid thermal properties
+Density = 2230 kg/m^3
+ThermalConductivity = 1.12 W/m/K
+SpecificHeat = 830 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=7546f96147b847a5ab00091f3c36b8ce

--- a/Data/CfdFluidMaterialProperties/Inconel601Solid.FCMat
+++ b/Data/CfdFluidMaterialProperties/Inconel601Solid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; Inconel601Solid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Inconel601_solid
+Type = Solid
+Description = INCONEL alloy 601 solid thermal properties
+Density = 8110 kg/m^3
+ThermalConductivity = 11.2 W/m/K
+SpecificHeat = 448 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=f3fb3ae6ebe54d98ad8fa01c74b6a3e8

--- a/Data/CfdFluidMaterialProperties/IronSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/IronSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; IronSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Iron_solid
+Type = Solid
+Description = Iron solid thermal properties
+Density = 7870 kg/m^3
+ThermalConductivity = 76.2 W/m/K
+SpecificHeat = 440 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=654ca9c358264b5392d43315d8535b7d

--- a/Data/CfdFluidMaterialProperties/PolypropyleneSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/PolypropyleneSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; PolypropyleneSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Polypropylene_solid
+Type = Solid
+Description = Polypropylene solid thermal properties
+Density = 918 kg/m^3
+ThermalConductivity = 0.249 W/m/K
+SpecificHeat = 1920 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=a882a1c603374e278d062f106dfda95b

--- a/Data/CfdFluidMaterialProperties/QuartzSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/QuartzSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; QuartzSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Quartz_solid
+Type = Solid
+Description = Fused quartz solid thermal properties
+Density = 2200 kg/m^3
+ThermalConductivity = 1.4 W/m/K
+SpecificHeat = 700 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=ffccd1bca743445ca3bc1706a52974dd

--- a/Data/CfdFluidMaterialProperties/SandSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/SandSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; SandSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Sand_solid
+Type = Solid
+Description = Dry sand solid thermal properties
+Density = 1650 kg/m^3
+ThermalConductivity = 0.305 W/m/K
+SpecificHeat = 776 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=18a1e365613b478f880e5506d6fb2ec1

--- a/Data/CfdFluidMaterialProperties/SilverSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/SilverSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; SilverSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Silver_solid
+Type = Solid
+Description = Silver solid thermal properties
+Density = 10491 kg/m^3
+ThermalConductivity = 419 W/m/K
+SpecificHeat = 234 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=63cbd043a31f4f739ddb7632c1443d33

--- a/Data/CfdFluidMaterialProperties/StainlessSteel316Solid.FCMat
+++ b/Data/CfdFluidMaterialProperties/StainlessSteel316Solid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; StainlessSteel316Solid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = StainlessSteel316_solid
+Type = Solid
+Description = AISI 316 stainless steel solid thermal properties
+Density = 8000 kg/m^3
+ThermalConductivity = 14.6 W/m/K
+SpecificHeat = 500 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=1336be6d0c594b55afb5ca8bf1f3e042

--- a/Data/CfdFluidMaterialProperties/StyrofoamSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/StyrofoamSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; StyrofoamSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Styrofoam_solid
+Type = Solid
+Description = Rigid polystyrene foam solid thermal properties
+Density = 32 kg/m^3
+ThermalConductivity = 0.029 W/m/K
+SpecificHeat = 1210 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=c98422e64d1f4bfa98e9d82dc89eaee6

--- a/Data/CfdFluidMaterialProperties/TitaniumSolid.FCMat
+++ b/Data/CfdFluidMaterialProperties/TitaniumSolid.FCMat
@@ -1,0 +1,13 @@
+; SPDX-FileCopyrightText: 2026 CfdOF contributors
+; TitaniumSolid
+;
+; FreeCAD Material card: see https://www.freecad.org/wiki/Material
+
+[FCMat]
+Name = Titanium_solid
+Type = Solid
+Description = Titanium solid thermal properties
+Density = 4500 kg/m^3
+ThermalConductivity = 17.0 W/m/K
+SpecificHeat = 528 J/kg/K
+ReferenceSource = https://www.matweb.com/search/DataSheet.aspx?MatGUID=66a15d609a3f4c829cb6ad08f0dafc01

--- a/package.xml
+++ b/package.xml
@@ -12,8 +12,8 @@
 
     <freecadmin>1.0.0</freecadmin>
 
-    <version>1.36.3</version>
-    <date>2026-05-08</date>
+    <version>1.36.4</version>
+    <date>2026-05-14</date>
 
     <!--[ Dependencies ]―――――――――――――――――――――――――――――――――――――――――――――――――――――-->
 


### PR DESCRIPTION
Hi,

This is part of multiple PRs for CHT support https://github.com/jaheyns/CfdOF/pull/265 that I am working on. I am breaking it down so it will be easier to review. In this PR, new solid thermophysical properties for different materials are added. The solid properties are not use by CfdOF any where. So this addition will not change any behavior.

The data are from matweb.com for generic data. User should note that for mission critical project, they should use data from their manufacturer. ReferenceSource  parameter in the card are not use, only for reference.

