### PR TITLE
Use create zones utility in the foundation version

### DIFF
--- a/Data/Templates/case/Allrun
+++ b/Data/Templates/case/Allrun
@@ -132,7 +132,13 @@ runCommand createPatch -overwrite
 %{%(zonesPresent%)
 %:True
 # Set cell zones contained inside the .stl surfaces
-runCommand topoSet -dict system/topoSetZonesDict
+which createZones > /dev/null 2>&1
+if [ $? == 0 ]
+then
+	runCommand createZones -dict system/createZonesDict
+else
+	runCommand topoSet -dict system/topoSetZonesDict
+fi
 
 %}
 %{%(initialisationZonesPresent%)

--- a/Data/Templates/case/Allrun.ps1
+++ b/Data/Templates/case/Allrun.ps1
@@ -124,7 +124,7 @@ runCommand createPatch -overwrite
 %{%(zonesPresent%)
 %:True
 # Set cell zones contained inside the .stl surfaces
-if( (Get-Command createNonConformalCouples) )
+if( (Get-Command createZones) )
 {
 	runCommand createZones -dict system/createZonesDict
 }

--- a/Data/Templates/case/Allrun.ps1
+++ b/Data/Templates/case/Allrun.ps1
@@ -124,7 +124,14 @@ runCommand createPatch -overwrite
 %{%(zonesPresent%)
 %:True
 # Set cell zones contained inside the .stl surfaces
-runCommand topoSet -dict system/topoSetZonesDict
+if( (Get-Command createNonConformalCouples) )
+{
+	runCommand createZones -dict system/createZonesDict
+}
+else
+{
+	runCommand topoSet -dict system/topoSetZonesDict
+}
 
 %}
 %{%(initialisationZonesPresent%)

--- a/Data/Templates/case/system/createZonesDict
+++ b/Data/Templates/case/system/createZonesDict
@@ -1,0 +1,27 @@
+%{%(zonesPresent%)
+%:True
+%[_header%]
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      topoSetZonesDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+%{%(zones%)
+%{%(zones/%(0%)/PartNameList%)
+%(0%)
+{
+    type        insideSurface;
+    zoneType    cell;
+
+    surface     triSurface;
+    file        "%(0%).stl";
+}
+%}
+%}
+
+// ************************************************************************* //
+%}

--- a/Data/TestFiles/cases/MeanVelocityForceCellZone/case/Allrun
+++ b/Data/TestFiles/cases/MeanVelocityForceCellZone/case/Allrun
@@ -67,7 +67,13 @@ fi
 runCommand createPatch -overwrite
 
 # Set cell zones contained inside the .stl surfaces
-runCommand topoSet -dict system/topoSetZonesDict
+which createZones > /dev/null 2>&1
+if [ $? == 0 ]
+then
+	runCommand createZones -dict system/createZonesDict
+else
+	runCommand topoSet -dict system/topoSetZonesDict
+fi
 
 # Parallel decomposition
 if [ ! -d processor0 ]

--- a/Data/TestFiles/cases/MeanVelocityForceCellZone/case/Allrun.ps1
+++ b/Data/TestFiles/cases/MeanVelocityForceCellZone/case/Allrun.ps1
@@ -53,7 +53,14 @@ echo "cAlpha 1;" > system/cAlpha
 runCommand createPatch -overwrite
 
 # Set cell zones contained inside the .stl surfaces
-runCommand topoSet -dict system/topoSetZonesDict
+if( (Get-Command createNonConformalCouples) )
+{
+	runCommand createZones -dict system/createZonesDict
+}
+else
+{
+	runCommand topoSet -dict system/topoSetZonesDict
+}
 
 # Parallel decomposition
 if( !(Test-Path -PathType Container processor0) )

--- a/Data/TestFiles/cases/MeanVelocityForceCellZone/case/Allrun.ps1
+++ b/Data/TestFiles/cases/MeanVelocityForceCellZone/case/Allrun.ps1
@@ -53,7 +53,7 @@ echo "cAlpha 1;" > system/cAlpha
 runCommand createPatch -overwrite
 
 # Set cell zones contained inside the .stl surfaces
-if( (Get-Command createNonConformalCouples) )
+if( (Get-Command createZones) )
 {
 	runCommand createZones -dict system/createZonesDict
 }


### PR DESCRIPTION
the foundation version made the `createZones` utility as a replacement for `topoSet` and it is alot easier to use.
and the topoSet is now marked as depricated in the foundation version.