### PR TITLE
fix error `cellZone region not specified` when selecting all in the foundation version

### DIFF
--- a/Data/Templates/case/system/fvOptions
+++ b/Data/Templates/case/system/fvOptions
@@ -66,6 +66,7 @@ momentumSource
     meanVelocityForceCoeffs
     {
         selectionMode   all;
+        cellZone        all; // for the foundation version
         fields          (U);
         direction       (%(meanVelocityForce/Direction%));
         Ubar            (%(meanVelocityForce/Ubar%));

--- a/Data/TestFiles/cases/PeriodicBoundaryAndMeanVelocityForce/case/system/fvOptions
+++ b/Data/TestFiles/cases/PeriodicBoundaryAndMeanVelocityForce/case/system/fvOptions
@@ -24,6 +24,7 @@ momentumSource
     meanVelocityForceCoeffs
     {
         selectionMode   all;
+        cellZone		all;
         fields          (U);
         direction       (1.0 0.0 0.0);
         Ubar            (0.005 0.0 0.0);

--- a/Data/TestFiles/cases/PeriodicBoundaryAndMeanVelocityForce/case/system/fvOptions
+++ b/Data/TestFiles/cases/PeriodicBoundaryAndMeanVelocityForce/case/system/fvOptions
@@ -24,7 +24,7 @@ momentumSource
     meanVelocityForceCoeffs
     {
         selectionMode   all;
-        cellZone		all;
+        cellZone        all; // for the foundation version
         fields          (U);
         direction       (1.0 0.0 0.0);
         Ubar            (0.005 0.0 0.0);


### PR DESCRIPTION
the foundation version use the cellZone keyword even when specifying all the mesh.

note: now I realized that I should make the PRs to the dev branch. so I will start from this PR to use the dev branch.