### PR TITLE
fix the extrusion ui in the meshrefinement task panel

### DIFF
--- a/Gui/TaskPanelCfdMeshRefinement.ui
+++ b/Gui/TaskPanelCfdMeshRefinement.ui
@@ -628,7 +628,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="QLabel" name="thicknessLabel">
         <property name="text">
          <string>Thickness</string>


### PR DESCRIPTION
the extrusion ui was messed up.
the `Angle` string was showing instead of the `Thickness` string. here is an image:
<img width="1920" height="1080" alt="ui-1e" src="https://github.com/user-attachments/assets/95e7d4f4-7d75-493c-9fc7-b4cccdefff6c" />


also when selecting `Rotational` for the type of extrusion the `Angel` and `Thickness` strings appear on the same place:
<img width="1920" height="1080" alt="ui-2e" src="https://github.com/user-attachments/assets/19cfb91f-c462-4040-a049-ebb6db6c9e72" />




