### PR TITLE
use a checkbox instead of a radio button in the scalarTransport ui

### DIFF
--- a/CfdOF/Solve/TaskPanelCfdScalarTransportFunctions.py
+++ b/CfdOF/Solve/TaskPanelCfdScalarTransportFunctions.py
@@ -53,16 +53,19 @@ class TaskPanelCfdScalarTransportFunctions:
         self.form.inputInjectionPointx.valueChanged.connect(self.inputInjectionPointChanged)
         self.form.inputInjectionPointy.valueChanged.connect(self.inputInjectionPointChanged)
         self.form.inputInjectionPointz.valueChanged.connect(self.inputInjectionPointChanged)
+
+        if hasattr(self.form.checkBoxDiffusivityFixed, "checkStateChanged"):
+            self.form.checkBoxDiffusivityFixed.checkStateChanged.connect(self.diffusivityCheckBoxChanged)
+        else:
+            self.form.checkBoxDiffusivityFixed.stateChanged.connect(self.diffusivityCheckBoxChanged)
         
         self.load()
         self.updateUI()
 
     def load(self):
         self.form.inputScalarFieldName.setText(self.obj.FieldName)
-        if self.obj.DiffusivityFixed:
-            self.form.radioUniformDiffusivity.toggle()
-        else:
-            self.form.radioViscousDiffusivity.toggle()
+        self.form.checkBoxDiffusivityFixed.setChecked(self.obj.DiffusivityFixed)
+        self.diffusivityCheckBoxChanged()
         setQuantity(self.form.inputDiffusivity, self.obj.DiffusivityFixedValue)
 
         self.form.checkRestrictToPhase.setChecked(self.obj.RestrictToPhase)
@@ -101,6 +104,14 @@ class TaskPanelCfdScalarTransportFunctions:
         self.form.checkRestrictToPhase.setVisible(mp)
         self.form.comboPhase.setVisible(mp)
 
+    def diffusivityCheckBoxChanged(self):
+        if self.form.checkBoxDiffusivityFixed.isChecked():
+            self.form.inputDiffusivity.setVisible(True)
+            self.form.specifiedCoefficientLabel.setVisible(True)
+        else:
+            self.form.inputDiffusivity.setVisible(False)
+            self.form.specifiedCoefficientLabel.setVisible(False)
+
     def inputInjectionPointChanged(self):
         if FreeCAD.GuiUp:
             self.prev_point_move_node.translation.setValue(
@@ -117,7 +128,7 @@ class TaskPanelCfdScalarTransportFunctions:
 
         # Type
         storeIfChanged(self.obj, 'FieldName', self.form.inputScalarFieldName.text())
-        storeIfChanged(self.obj, 'DiffusivityFixed', self.form.radioUniformDiffusivity.isChecked())
+        storeIfChanged(self.obj, 'DiffusivityFixed', self.form.checkBoxDiffusivityFixed.isChecked())
         storeIfChanged(self.obj, 'DiffusivityFixedValue', getQuantity(self.form.inputDiffusivity))
         storeIfChanged(self.obj, 'RestrictToPhase', self.form.checkRestrictToPhase.isChecked())
         storeIfChanged(self.obj, 'PhaseName', self.form.comboPhase.currentText())

--- a/Gui/TaskPanelCfdScalarTransportFunctions.ui
+++ b/Gui/TaskPanelCfdScalarTransportFunctions.ui
@@ -64,13 +64,6 @@
        <property name="bottomMargin">
         <number>8</number>
        </property>
-       <item row="3" column="0" colspan="2">
-        <widget class="QRadioButton" name="radioViscousDiffusivity">
-         <property name="text">
-          <string>Viscous/turbulent</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QLabel" name="labelPressure">
          <property name="text">
@@ -78,8 +71,15 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="0" colspan="2">
+        <widget class="QCheckBox" name="checkBoxDiffusivityFixed">
+         <property name="text">
+          <string>Fixed diffusivity</string>
+         </property>
+        </widget>
+       </item>
        <item row="4" column="0">
-        <widget class="QRadioButton" name="radioUniformDiffusivity">
+        <widget class="QLabel" name="specifiedCoefficientLabel">
          <property name="text">
           <string>Specified coefficient</string>
          </property>
@@ -311,8 +311,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>inputScalarFieldName</tabstop>
-  <tabstop>radioViscousDiffusivity</tabstop>
-  <tabstop>radioUniformDiffusivity</tabstop>
+  <tabstop>checkBoxDiffusivityFixed</tabstop>
   <tabstop>inputDiffusivity</tabstop>
   <tabstop>inputInjectionRate</tabstop>
   <tabstop>inputInjectionPointx</tabstop>


### PR DESCRIPTION
I think using a check box make it clear in the ui and also I made the speciefied coefficient disappear when the the check box is disabled.
