### PR TITLE
fix number of processors and number of threads ui being wider than the rest of the mesh ui

### DIFF
--- a/Gui/TaskPanelCfdMesh.ui
+++ b/Gui/TaskPanelCfdMesh.ui
@@ -346,13 +346,13 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <property name="leftMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="topMargin">
        <number>0</number>
       </property>
       <property name="rightMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="bottomMargin">
        <number>0</number>


### PR DESCRIPTION
before:
<img width="1920" height="1080" alt="ui 3" src="https://github.com/user-attachments/assets/206e3474-af09-4940-812b-08c99d73a190" />
after:
<img width="1920" height="1080" alt="ui 2" src="https://github.com/user-attachments/assets/07a41448-1ac7-47d3-8cfb-b7bf7160b082" />
