### PR TITLE
Add residual plot button to solver panel

### DIFF
--- a/CfdOF/Solve/TaskPanelCfdSolverControl.py
+++ b/CfdOF/Solve/TaskPanelCfdSolverControl.py
@@ -76,6 +76,7 @@ class TaskPanelCfdSolverControl:
         self.form.pb_edit_inp.clicked.connect(self.editSolverInputFile)
         self.form.pb_run_solver.clicked.connect(self.runSolverProcess)
         self.form.pb_paraview.clicked.connect(self.openParaview)
+        self.form.pb_plot_residuals.clicked.connect(self.openResidualPlot)
         self.form.inputParallel.stateChanged.connect(self.updateUI)
 
         self.Start = time.time()
@@ -324,6 +325,14 @@ class TaskPanelCfdSolverControl:
         print_err = self.solver_object.Proxy.solver_process.processErrorOutput(lines)
         if print_err is not None:
             self.consoleMessage(print_err, 'Error')
+
+    def openResidualPlot(self):
+        plotter = self.solver_object.Proxy.residual_plotter
+        if not plotter.times or not any(plotter.values.values()):
+            self.consoleMessage("No residual data available to plot", 'Error')
+            return
+        plotter.updated = True
+        plotter.refresh()
 
     def openParaview(self):
         QApplication.setOverrideCursor(Qt.WaitCursor)

--- a/Gui/TaskPanelCfdSolverControl.ui
+++ b/Gui/TaskPanelCfdSolverControl.ui
@@ -234,15 +234,9 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QLabel" name="label_5">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
+      <widget class="QPushButton" name="pb_plot_residuals">
        <property name="text">
-        <string/>
+        <string>Residuals</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This PR add a new GUI button to solver panel which when click will display a residual plot in the case that the user accidentally close it. There is no way to show it again unless the simulation start again. So this button was added.

All test pass. 

<img width="1539" height="920" alt="Screenshot_20260719_235143" src="https://github.com/user-attachments/assets/38a705b3-77f7-4c65-a6de-1e5fc8fa9711" />